### PR TITLE
chore(release): 首发后收尾 — 修数据包缺数据/堵根因/清安全告警

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,2 +1,0 @@
-version: 2
-updates: []

--- a/package.json
+++ b/package.json
@@ -33,5 +33,10 @@
     "typescript-eslint": "^8.62.0",
     "vite": "^8.1.0",
     "vitest": "^4.1.9"
+  },
+  "pnpm": {
+    "overrides": {
+      "js-yaml@3": "^3.15.0"
+    }
   }
 }

--- a/packages/source-2023/package.json
+++ b/packages/source-2023/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cndiv/source-2023",
-  "version": "2023.0.0",
+  "version": "2023.0.1",
   "description": "China administrative division data snapshot for year 2023 (NBS five-level: province/city/county/township/village)",
   "license": "MIT",
   "files": [
@@ -27,5 +27,8 @@
     "type": "git",
     "url": "git+https://github.com/tonyc726/china-administrative-division.git",
     "directory": "packages/source-2023"
+  },
+  "scripts": {
+    "prepublishOnly": "node -e \"const s=require('fs').statSync('data/divisions.csv').size;if(s<1e6){console.error('✋ divisions.csv 缺失或过小('+s+'B)——拒绝发布空数据包(CI 无 CSV 源，须本地发布)');process.exit(1)}\""
   }
 }

--- a/packages/source-history/package.json
+++ b/packages/source-history/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cndiv/source-history",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "China administrative division history (GB/T 2260, 1980–2021), year-versioned by composite (code, year)",
   "license": "MIT",
   "files": [
@@ -28,5 +28,8 @@
     "type": "git",
     "url": "git+https://github.com/tonyc726/china-administrative-division.git",
     "directory": "packages/source-history"
+  },
+  "scripts": {
+    "prepublishOnly": "node -e \"const s=require('fs').statSync('data/divisions.csv').size;if(s<1e6){console.error('✋ divisions.csv 缺失或过小('+s+'B)——拒绝发布空数据包(CI 无 CSV 源，须本地发布)');process.exit(1)}\""
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  js-yaml@3: ^3.15.0
+
 importers:
 
   .:
@@ -1337,8 +1340,8 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+  js-yaml@3.15.0:
+    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
     hasBin: true
 
   js-yaml@4.2.0:
@@ -2031,6 +2034,7 @@ packages:
 
   whatwg-encoding@1.0.5:
     resolution: {integrity: sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
@@ -3360,7 +3364,7 @@ snapshots:
   jiti@2.6.1:
     optional: true
 
-  js-yaml@3.14.2:
+  js-yaml@3.15.0:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
@@ -3694,7 +3698,7 @@ snapshots:
   read-yaml-file@1.1.0:
     dependencies:
       graceful-fs: 4.2.11
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       pify: 4.0.1
       strip-bom: 3.0.0
 


### PR DESCRIPTION
## 背景

合并 #62 自动触发 `release.yml`，`changeset publish` 不理会 changesets 的 `ignore` 字段，把 CI 里无 CSV 源（gitignored）的数据包也发了 → 发出 6KB 空包。本 PR 收尾。

## 变更

**① 数据包已修复（npm 侧已生效）**
- `@cndiv/source-2023@2023.0.1`（52.7MB 含 CSV）、`@cndiv/source-history@0.2.1`（9.2MB 含 CSV）——本地重建后发布
- 坏版 `2023.0.0`/`0.2.0` 已 `npm deprecate`
- 本 PR 把仓库版本对齐到已发布补丁版

**② 堵根因**
- `source-2023`/`source-history` 加 `prepublishOnly` 守卫：`divisions.csv` 缺失或 <1MB 时拒绝发布，杜绝 CI（无 CSV）再发空数据包

**③ 清理**
- 删除无效 `.github/dependabot.yml`（`updates: []` 违反 Dependabot schema → 配置报错）
- `pnpm.overrides` `js-yaml@3` → `^3.15.0`：清掉 changesets 传递依赖的 moderate 漏洞（`read-yaml-file` 允许 `^3.6.1`，3.15.0 在范围内、不破坏）→ Dependabot 告警 2 → 1

## 门禁
frozen-lockfile / build / test(172) / audit（js-yaml moderate 已清）全绿。

## 合并安全性
不会再触发坏发布：代码包与数据补丁版均已在 npm，`changeset publish` 会全部跳过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)