### PR TITLE
docs: README 可读性重构 + cndiv 标识 + 文档站暗色修复 + 收尾补漏

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,30 @@
+# ============================================================
+# @cndiv/monorepo · 环境变量样例
+# 复制为 .env 后按需填写。所有变量均可选，缺省时走代码内置默认值。
+# 变量名与代码 process.env.* 引用一一对应，请勿臆增。
+# ============================================================
+
+# ---- 发布（npm）----
+# changeset publish 到 npm 的凭证；仅发版 / CI 需要，本地开发可留空。
+NPM_TOKEN=""
+
+# ---- 文档站部署（docs-site · VitePress）----
+# 站点 base 路径。默认 "/"（Vercel / Netlify / Cloudflare 根域）。
+# 部署到 GitHub Pages 子路径时设为 "/china-administrative-division/"。
+DOCS_BASE="/"
+# OG 分享图与 canonical 的绝对站点 URL（无尾斜杠）。默认 GitHub Pages 地址；
+# 部署到自有根域时覆盖（同时把 DOCS_BASE 设回 "/"）。
+DOCS_SITE_URL="https://tonyc726.github.io/china-administrative-division"
+
+# ---- 变更抽取 LLM（@cndiv/extractor）----
+# 抽取器默认走规则法兜底；接入 LLM 时二选一：
+#   ① 本地 Ollama —— 设 USE_OLLAMA=1，前置 `ollama serve` + `ollama pull qwen2.5`
+#      （默认模型 qwen2.5、地址 http://localhost:11434，均已内置，无需额外配置）。
+USE_OLLAMA=""
+#   ② 云端阿里百炼（DashScope，默认模型 qwen-plus）—— 填控制台申请的 API Key（sk-...）。
+DASHSCOPE_API_KEY=""
+
+# ---- 测试 ----
+# 置 1 时运行 @cndiv/crawler 的活体网络契约 smoke（真实请求 dmfw）；
+# 常规 `pnpm test` 默认跳过、不触网。
+NETWORK_SMOKE=""

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,2 +1,0 @@
-version: 2
-updates: []

--- a/README.md
+++ b/README.md
@@ -1,172 +1,74 @@
+<p align="center">
+  <img src="./docs-site/public/logo.svg" width="88" height="88" alt="cndiv logo">
+</p>
+
 # China Administrative Division · 中国行政区划数据基础设施
 
 [![Docs](https://img.shields.io/badge/%E5%9C%A8%E7%BA%BF%E6%96%87%E6%A1%A3-cndiv-brightgreen?logo=vuedotjs)](https://tonyc726.github.io/china-administrative-division/)
 [![Validate Patches](https://github.com/tonyc726/china-administrative-division/actions/workflows/validate-patches.yml/badge.svg)](https://github.com/tonyc726/china-administrative-division/actions/workflows/validate-patches.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 
-> 📖 **在线文档**：<https://tonyc726.github.io/china-administrative-division/> —— 快速上手、包 API 参考、数据下载与采集运维，一站可查。
+**中华人民共和国行政区划代码的历史数据库,以及一套持续更新它的基础设施。**
 
-中华人民共和国行政区划代码的历史数据库与可持续更新基础设施。提供 **GB2260 国标**（省/市/县，1980–2023）与 **NBS 统计用区划代码**（省/市/县/乡/村五级，2009–2023）的历年快照。
+- **GB2260 国标** —— 省 / 市 / 县三级,1980–2023
+- **NBS 统计用区划代码** —— 省 / 市 / 县 / 乡 / 村五级,2009–2023
 
-## 背景：为什么是 v2
+原数据源国家统计局 `stats.gov.cn` 自 2024 年起停更、2026 年转向国家地名信息库。v2 因此改为 **「2023 基线快照 + 社区 Patch 增量 + 多源合成」**,数据与代码彻底解耦、用户侧零爬虫。
 
-原数据源国家统计局 `stats.gov.cn`（统计用区划代码和城乡划分代码）自 **2024 年起停止公开发布**、**2026 年起统一转向「国家地名信息库」**（dmfw.mca.gov.cn），全量五级数据已无官方活源。
-
-因此 v2 架构从"镜像一个源"转为**"2023 基线快照 + 社区 Patch 增量 + 多源合成"**，并把数据与代码彻底解耦：
-
-```
-构建期(维护者)                     分发                用户运行期
-历史源/dmfw/镜像 → 合成 → SQLite → NPM @cndiv/source-YYYY → cndiv hydrate → ~/.cndiv/cache.db
-                                  + GitHub Release 归档        + patches/*.json  → cndiv apply-patch
-```
-
-- **用户侧零爬虫**：只从 NPM 拉取数据包注水到本地 SQLite。
-- **大数据不进 git**：仓库历史曾因 GB 级 SQLite 膨胀并被迫 `git-filter-repo` 清理；现以 `.gitignore`（内容型规则）+ pre-commit 钩子杜绝复发。数据走 NPM / GitHub Release 分发。
-
-## Monorepo 结构
-
-> 本表为目录结构的**权威来源**（以实际 `packages/` 现状为准）；`docs/` 内的设计稿仅为历史方案，结构以本表为准。
-
-| 包 | 职责 |
-|---|---|
-| [`@cndiv/core`](./packages/core) | 领域模型（5 级区划）与区划码校验（`validateCode` / `getLevelFromCode` / `getParentCode`，码结构 2+2+2+3+3） |
-| [`@cndiv/data-protocol`](./packages/data-protocol) | 唯一真相源：SQLite `DATABASE_SCHEMA`（复合主键 `code,year`）+ 基于 Zod 的 Patch 协议（`validatePatch`）+ 邮编/区号契约（`PostalRecordSchema`） |
-| [`@cndiv/cli`](./packages/cli) | `cndiv` 命令行：`hydrate` / `apply-patch` / `migrate` / `export` / `backfill`（库 API 与 bin 入口分离，import 零副作用） |
-| [`@cndiv/crawler`](./packages/crawler) | 增量采集：① dmfw 逐层 BFS + 并发限流 + 断点续爬，差分产出 Patch（`validatePatch` 守门、空名过滤；覆盖 level 1–4，无村级；`canonicalizeParent` 归一化占位层，消解 dmfw 扁平↔NBS 假 move）；② `cndiv-postal` 抓 ip138 邮编/区号；③ `cndiv-verify` patch 结构性门禁（码/层级/父级自洽 + baseline 引用完整性，离线确定性、CI 已接入；商业地图交叉校验 `cross` 为合规桩不落库，见 [`docs/patch-校验与交叉校验.md`](./docs/patch-校验与交叉校验.md)） |
-| [`@cndiv/extractor`](./packages/extractor) | NLP 变更提取器：行政区划变更公告 → 结构化 Patch 操作（规则法兜底 + 可插拔 LLM，Tool Use 失败兜底；产物经 `validatePatch` 守门） |
-| [`@cndiv/reader`](./packages/reader) | cache.db 最小**只读查询 API**：`openCache` / `findByCode` / `getChildren` / `getDescendants`（薄封装 better-sqlite3，屏蔽复合主键 `(code,year)` 与市辖区占位层两个坑） |
-| [`@cndiv/source-<year>`](./packages/source-2023) | 区划数据包：某年份 `divisions.csv` + `manifest.json`（SHA-512），由 `cndiv hydrate --year=<YYYY>` 注水 |
-| [`@cndiv/source-history`](./packages/source-history) | GB2260 历史数据包（1980–2021，逐行 `year` 版本化，131356 条 / 42 年），由 `cndiv hydrate --year=history` 注水 |
-| [`@cndiv/source-postal`](./packages/source-postal) | 邮编/区号数据包：`postal.csv`（县级，源自 ip138）+ `manifest.json` |
-| [`legacy/`](./legacy) | v1 旧版爬虫 **已退役墓碑** 🪦（移出 workspace；价值已全部迁入 v2——见 [`legacy/README`](./legacy/README.md)：历史→`source-history`、ip138→`crawler`、仅留 JSON→SQLite 生产链备查） |
-
-## 数据获取
-
-### 方式一：CLI 注水（推荐）
+## 快速上手
 
 ```bash
-npm i -g @cndiv/cli      # 或 pnpm add -g
+npm i -g @cndiv/cli
 
-cndiv hydrate --year=2023     # 下载 @cndiv/source-2023 → ~/.cndiv/cache.db
-cndiv apply-patch --patch=patches/2025/310115-pudong-update.json
-cndiv export --year=2023 --output=divisions-2023.csv
+cndiv hydrate --year=2023                    # 下载 2023 全量数据 → 本地 ~/.cndiv/cache.db(标准 SQLite)
+cndiv export --year=2023 --output=out.csv    # 导出 CSV
 ```
 
-> ⚠️ 参数使用 `--key=value` 连写形式（如 `--year=2023`）。
-
-### 方式二：直接下载历史快照
-
-完整历年数据（GB2260 1980–2023、NBS 2009–2023 五级 SQLite + 原始 JSON）见 GitHub Release
-[`data-snapshot-2023`](https://github.com/tonyc726/china-administrative-division/releases/tag/data-snapshot-2023)。
-逐文件 SHA-256 完整性清单见 [`docs/DATA-ASSETS.md`](./docs/DATA-ASSETS.md)，数据字典见 Release 内 `SQLITE_DATA_README.md`。
-
-```bash
-# 校验并解压
-shasum -a 256 -c SHA256SUMS.txt
-tar -xzf nbs-sqlite-2009-2023.tar.gz
-sqlite3 NBS.2023.sqlite "SELECT count(*) FROM village;"   # → 620573
-```
-
-## 在代码中使用
-
-四个面向消费者的代码包，按需安装：
-
-| 我想… | 用 | 入口 |
-|---|---|---|
-| 校验/解析 12 位区划码（判级、取父码、补零） | [`@cndiv/core`](./packages/core) | 纯函数零依赖 |
-| 校验社区 Patch / 复用 SQLite schema | [`@cndiv/data-protocol`](./packages/data-protocol) | `validatePatch` / `DATABASE_SCHEMA` |
-| 命令行注水、应用 patch、导出 | [`@cndiv/cli`](./packages/cli) | `cndiv` 命令（见上「数据获取」） |
-| 在 JS 里查询注水后的区划数据 | [`@cndiv/reader`](./packages/reader) | `openCache().findByCode(...)` |
-
-### 码工具（`@cndiv/core`，纯函数）
-
-```ts
-import { validateCode, getLevelFromCode, getParentCode, DIVISION_LEVEL } from '@cndiv/core';
-
-validateCode('310115000000');                          // true（结构 + 省码白名单，不保证真实存在）
-getLevelFromCode('310115000000');                      // 3 (COUNTY)
-getParentCode('310115000000', DIVISION_LEVEL.COUNTY);  // '310100000000'
-```
-
-> 16 个导出全清单与坑（无「码→名」反查、`normalizeCode` 不校验省码、`getParentCode` 需先判级等）见 [`@cndiv/core` README](./packages/core)。可跑示例：`npx tsx packages/core/examples/code-tools.ts`。
-
-### 查询注水后的数据
-
-`cndiv hydrate` 把数据落到 `~/.cndiv/cache.db`（标准 SQLite）。用 [`@cndiv/reader`](./packages/reader) 查询——它薄封装 `better-sqlite3`、只读打开，并自动屏蔽两个坑：**复合主键 `(code, year)`**（所有查询强制 `year`）与**直辖市「市辖区」占位层**（`skipPlaceholder` 穿透到真实区县）。
+在代码里查询(`@cndiv/reader` 只读封装 `better-sqlite3`):
 
 ```ts
 import { openCache } from '@cndiv/reader';
 
-const cn = openCache(); // 默认 ~/.cndiv/cache.db，只读
-cn.findByCode('110101000000', 2023); // → Division（东城区）
-cn.getChildren('110000000000', 2023, { skipPlaceholder: true }); // → [东城区, 西城区]
-cn.getDescendants('110000000000', 2023); // 递归全部后代
+const cn = openCache();
+cn.findByCode('110101000000', 2023);                              // → 东城区
+cn.getChildren('110000000000', 2023, { skipPlaceholder: true });  // → [东城区, 西城区, …]
 cn.close();
 ```
 
-> 也可不用 reader、自带 `better-sqlite3` 直接写 SQL（reader 即此封装）——底层范式（点查 / 子级 / 递归 CTE / 配合 `@cndiv/core` 码工具）见可跑示例：`npx tsx packages/cli/examples/query-cache.ts`。
+> 不想用 CLI?完整历年数据(五级 SQLite + 原始 JSON)见 GitHub Release
+> [`data-snapshot-2023`](https://github.com/tonyc726/china-administrative-division/releases/tag/data-snapshot-2023)。
 
-### 校验 Patch（`@cndiv/data-protocol`）
+## 装哪个包
 
-```ts
-import { validatePatch } from '@cndiv/data-protocol';
-const r = validatePatch(JSON.parse(patchJson));
-if (!r.success) throw new Error(r.error); // success 为 true 时 r.data 是规范化后的 Patch
-```
+大多数使用者只需下面一个。**完整 API、示例与已知坑请看[在线文档](https://tonyc726.github.io/china-administrative-division/)。**
 
-> 可跑示例：`npx tsx packages/data-protocol/examples/validate-patch.ts`。
+| 我想做什么 | 用这个包 |
+|---|---|
+| 校验 / 解析 12 位区划码(判级、取父码、补零) | [`@cndiv/core`](./packages/core) —— 纯函数、零依赖 |
+| 在代码里查询注水后的数据 | [`@cndiv/reader`](./packages/reader) |
+| 命令行:注水、应用 patch、导出 | [`@cndiv/cli`](./packages/cli) |
+| 校验社区 Patch / 复用 SQLite schema | [`@cndiv/data-protocol`](./packages/data-protocol) |
 
-## 数据模型
-
-12 位统计用区划代码结构 **2+2+2+3+3**（省/市/县/乡镇街道/村居委会）：
-
-```
-11      01      01      001       001
-省(2)   市(2)   县(2)   乡镇(3)   村(3)
-```
-
-存储为扁平邻接表 `divisions(code, name, level, parent_code, year, status, source_type, confidence_score)`，复合主键 `(code, year)` 支持同一区划码跨年份版本化。来源置信度分 4 档：`official_nbs > mca_decree > community > shadow_map`。
+> 维护侧包(采集 `@cndiv/crawler`、公告抽取 `@cndiv/extractor`)与数据包(`@cndiv/source-*`)见文档站「包参考」。
 
 ## 贡献 Patch
 
-行政区划变更（撤县设区、更名、新设社区等）以 JSON Patch 提交到 `patches/<YYYY>/`：
-
-```jsonc
-{
-  "meta": { "author": "...", "source_url": "...", "evidence_confidence": "high", "apply_after": "2023-baseline" },
-  "operations": [
-    { "op": "add", "code": "310115001002", "name": "新设立社区居委会", "level": 5, "parent_code": "310115001000" },
-    { "op": "update", "code": "310115102000", "status": "deprecated", "note": "撤销合并" }
-  ]
-}
-```
-
-PR 会由 CI（`validate-patches.yml`）用 `validatePatch` 自动校验。本地校验：`node scripts/validate-patches.mjs`。
-
-> 维护者采集运维（年度全量校准 + 日常 xzqh 事件增量、产物合并、level 5 村级冻结边界）见 [`docs/采集运维手册.md`](./docs/采集运维手册.md)。
+行政区划变更(撤县设区、更名、新设社区等)以 JSON Patch 提交到 `patches/<YYYY>/`,PR 由 CI 自动校验。
+提交格式与本地校验见 [贡献指南](https://tonyc726.github.io/china-administrative-division/guide/contributing-patch)。
 
 ## 开发
 
 ```bash
-pnpm install         # 自动启用 .githooks（pre-commit 拦大文件/数据库）
+pnpm install         # 自动启用 .githooks(pre-commit 拦大文件 / 数据库)
 pnpm build           # tsc -b 增量构建全部包
 pnpm typecheck && pnpm lint && pnpm test && pnpm validate-patches   # 本地复刻 CI 门禁
 ```
 
-### 发版（changesets 多包治理）
-
-```bash
-pnpm changeset           # 为本次改动登记版本意图（选包 + major/minor/patch）
-pnpm version-packages    # 消费 changeset：bump 版本 + 写 CHANGELOG
-pnpm release             # build + changeset publish 到 npm
-```
-
-> 数据包 `@cndiv/source-*` 按数据年份独立版本化，已在 changesets `ignore`，不随代码包 bump。
-> 数据闭环：`crawler` 抓取 → `patches/<YYYY>/` → `apply-patch`（克隆到目标年）→ `backfill` 导回 `source-<year>/divisions.csv` → 重建数据包。
+架构设计、采集运维、发版流程见[在线文档](https://tonyc726.github.io/china-administrative-division/)。
 
 ## 数据来源与许可
 
-数据来源于公开政府网站（国家统计局、民政部国家地名信息库），仅供学习与研究使用。代码以 [MIT](./LICENSE) 许可。
+数据来源于公开政府网站(国家统计局、民政部国家地名信息库),仅供学习与研究使用。代码以 [MIT](./LICENSE) 许可。
 
-- 国家地名信息库（增量主源）：https://dmfw.mca.gov.cn
-- 历史五级镜像参考：[modood/Administrative-divisions-of-China](https://github.com/modood/Administrative-divisions-of-China)（WTFPL）
+- 国家地名信息库(增量主源):<https://dmfw.mca.gov.cn>
+- 历史五级镜像参考:[modood/Administrative-divisions-of-China](https://github.com/modood/Administrative-divisions-of-China)(WTFPL)

--- a/docs-site/.vitepress/config.ts
+++ b/docs-site/.vitepress/config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
   metaChunk: true,
 
   head: [
+    ['link', { rel: 'icon', type: 'image/svg+xml', href: `${base}favicon.svg` }],
     ['meta', { name: 'keywords', content: '中国行政区划,行政区划代码,GB2260,统计用区划代码,NBS,城乡划分代码,国家地名信息库,dmfw,邮编,区号,SQLite,行政区划历史数据' }],
     ['meta', { property: 'og:type', content: 'website' }],
     ['meta', { property: 'og:title', content: '中国行政区划数据基础设施 · @cndiv' }],
@@ -42,7 +43,7 @@ export default defineConfig({
   ],
 
   themeConfig: {
-    logo: undefined,
+    logo: '/logo.svg',
     outline: { level: [2, 3], label: '本页目录' },
     search: {
       provider: 'local',

--- a/docs-site/.vitepress/theme/custom.css
+++ b/docs-site/.vitepress/theme/custom.css
@@ -3,6 +3,10 @@
    暖羊皮纸底 · 唯一墨蓝强调（≤5% 面积）· 衬线扛层级（锁 500，无斜体）
    暖调灰阶四级 · 微阴影非硬投影 · 用字体层级替代装饰
    Tokens 源自 tw93/Kami references/tokens.json + design.md
+
+   暗色对比度原则：正文/强调/面/边框一律引用会随主题切换的 --vp-c-*
+   语义变量，切勿直接写 --kami-* 固定亮色（否则暗底下近黑字、深墨蓝字不可见）。
+   仅「品牌实心」元素（brand 按钮、hero 光晕）保留 --kami-brand。
    ============================================================ */
 
 :root {
@@ -81,9 +85,15 @@
   --vp-custom-block-warning-text: var(--kami-breaking-fg);
   --vp-custom-block-warning-border: transparent;
 
-  /* 首页 hero */
+  /* 首页 hero：标题墨蓝，logo 背后一层墨蓝→朱砂柔光 */
   --vp-home-hero-name-color: var(--kami-brand);
   --vp-home-hero-name-background: none;
+  --vp-home-hero-image-background-image: linear-gradient(
+    -45deg,
+    rgba(27, 54, 93, 0.14),
+    rgba(198, 64, 47, 0.1)
+  );
+  --vp-home-hero-image-filter: blur(46px);
 }
 
 /* ---------- 暗色主题：deep-dark 暖炭 ---------- */
@@ -113,6 +123,15 @@
   --vp-custom-block-tip-bg: rgba(126, 163, 207, 0.1);
   --vp-custom-block-warning-bg: rgba(139, 69, 19, 0.16);
   --vp-custom-block-warning-text: #d8a878;
+
+  /* hero 主标题在暗底改用提亮墨蓝；柔光加浓一档 */
+  --vp-home-hero-name-color: var(--vp-c-brand-1);
+  --vp-home-hero-image-background-image: linear-gradient(
+    -45deg,
+    rgba(126, 163, 207, 0.22),
+    rgba(198, 64, 47, 0.16)
+  );
+  --vp-home-hero-image-filter: blur(52px);
 }
 
 /* ============================================================
@@ -142,7 +161,7 @@ h1.title {
   line-height: 1.25;
   margin-top: 3rem;
   padding-top: 1.6rem;
-  border-top: 1px solid var(--kami-border);
+  border-top: 1px solid var(--vp-c-divider);
 }
 .vp-doc h3 {
   font-size: 1.2rem;
@@ -157,22 +176,22 @@ h1.title {
   letter-spacing: 0.01em;
 }
 .vp-doc {
-  color: var(--kami-near-black);
+  color: var(--vp-c-text-1);
 }
 
-/* 强调：serif 不加粗，用墨蓝 + 字重 500 表达 */
+/* 强调：serif 不加粗，用墨蓝 + 字重 500 表达（暗底自动提亮为 brand-1） */
 .vp-doc strong {
   font-weight: 600;
-  color: var(--kami-brand);
+  color: var(--vp-c-brand-1);
 }
 
 /* 引用块：墨蓝左栏 + serif，编辑感 */
 .vp-doc blockquote {
-  border-left: 3px solid var(--kami-brand);
-  background: var(--kami-ivory);
+  border-left: 3px solid var(--vp-c-brand-1);
+  background: var(--vp-c-bg-soft);
   border-radius: 0 6px 6px 0;
   padding: 0.6rem 1.2rem;
-  color: var(--kami-olive);
+  color: var(--vp-c-text-2);
 }
 .vp-doc blockquote p {
   font-family: var(--kami-serif);
@@ -181,7 +200,7 @@ h1.title {
 /* 禁斜体（Kami 不变量 #10，屏幕端仅诗性行例外，此处一律正体） */
 .vp-doc em {
   font-style: normal;
-  color: var(--kami-brand);
+  color: var(--vp-c-brand-1);
 }
 
 /* ============================================================
@@ -190,11 +209,11 @@ h1.title {
 
 .vp-doc a {
   font-weight: 500;
-  text-decoration-color: var(--kami-tag);
+  text-decoration-color: var(--vp-c-divider);
   text-underline-offset: 3px;
 }
 .vp-doc a:hover {
-  text-decoration-color: var(--kami-brand);
+  text-decoration-color: var(--vp-c-brand-1);
 }
 
 /* 表格：暖表头、行分隔线柔和 */
@@ -208,18 +227,18 @@ h1.title {
   font-weight: 600;
   font-size: 0.86rem;
   letter-spacing: 0.02em;
-  background: var(--kami-parchment-2);
-  color: var(--kami-dark-warm);
-  border: 1px solid var(--kami-border);
+  background: var(--vp-c-bg-alt);
+  color: var(--vp-c-text-2);
+  border: 1px solid var(--vp-c-border);
 }
 .vp-doc td {
-  border: 1px solid var(--kami-border-soft);
+  border: 1px solid var(--vp-c-divider);
 }
 .vp-doc tr {
   background: transparent;
 }
 .vp-doc tr:nth-child(2n) {
-  background: rgba(232, 230, 220, 0.32);
+  background: var(--vp-c-bg-soft);
 }
 
 /* 行内代码：暖 tint 底、墨蓝字 */
@@ -247,7 +266,7 @@ h1.title {
   border-color: var(--vp-c-border);
 }
 .vp-doc div[class*='language-'] .lang {
-  color: var(--kami-stone);
+  color: var(--vp-c-text-3);
 }
 
 /* ============================================================
@@ -272,17 +291,17 @@ h1.title {
   letter-spacing: 0.01em;
 }
 
-/* 侧栏当前项：墨蓝左栏，克制 */
+/* 侧栏当前项：墨蓝左栏，克制（暗底自动提亮） */
 .VPSidebarItem.is-active > .item .link .text,
 .VPSidebarItem.is-active > .item .text {
-  color: var(--kami-brand) !important;
+  color: var(--vp-c-brand-1) !important;
   font-weight: 600;
 }
 .VPSidebarItem .text {
   font-size: 0.9rem;
 }
 .VPSidebarItem.level-0 > .item > .indicator {
-  background-color: var(--kami-brand) !important;
+  background-color: var(--vp-c-brand-1) !important;
 }
 
 /* ============================================================
@@ -290,33 +309,39 @@ h1.title {
    —— serif 主标题、墨蓝、克制卡片、微阴影
    ============================================================ */
 
-/* 加宽主区并压一档字号，避免中文主标题断字换行 */
+/* 加宽主区，允许中文主标题平衡换行（有 logo 图时为两栏，不再强制单行） */
 .VPHero .main {
-  max-width: 820px;
+  max-width: 100%;
 }
 .VPHero .name {
-  font-size: 2.9rem;
-  line-height: 1.15;
+  font-size: 2.7rem;
+  line-height: 1.16;
   letter-spacing: 0;
-  white-space: nowrap;
+  text-wrap: balance;
 }
 .VPHero .text {
-  font-size: 1.55rem;
-  color: var(--kami-dark-warm);
+  font-size: 1.5rem;
+  color: var(--vp-c-text-2);
   line-height: 1.3;
   margin-top: 0.4rem;
 }
 .VPHero .tagline {
   font-family: var(--kami-serif);
-  color: var(--kami-olive);
+  color: var(--vp-c-text-2);
   line-height: 1.6;
   font-size: 1.05rem;
 }
+/* hero logo 图：不裁切、留白呼吸，柔光在其后 */
+.VPHero .image-src {
+  max-width: 240px;
+  max-height: 240px;
+}
 
-/* 主 CTA：墨蓝实心；次 CTA：暖沙描边 */
+/* 主 CTA：墨蓝实心（品牌色保留，双模式白字可读）；次 CTA：暖沙描边 */
 .VPButton.brand {
   background: var(--kami-brand);
   border-color: var(--kami-brand);
+  color: #faf9f5;
   font-weight: 500;
 }
 .VPButton.brand:hover {
@@ -324,20 +349,20 @@ h1.title {
   border-color: var(--kami-brand-light);
 }
 .VPButton.alt {
-  background: var(--kami-ivory);
-  border: 1px solid var(--kami-border);
-  color: var(--kami-dark-warm);
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-border);
+  color: var(--vp-c-text-2);
 }
 .VPButton.alt:hover {
-  border-color: var(--kami-brand);
-  color: var(--kami-brand);
-  background: var(--kami-ivory);
+  border-color: var(--vp-c-brand-1);
+  color: var(--vp-c-brand-1);
+  background: var(--vp-c-bg-soft);
 }
 
-/* Feature 卡片：ivory 面 + 柔边 + whisper 阴影，hover 墨蓝细边 */
+/* Feature 卡片：抬起面 + 柔边 + whisper 阴影，hover 墨蓝细边 */
 .VPFeature {
-  background: var(--kami-ivory);
-  border: 1px solid var(--kami-border);
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-border);
   border-radius: 10px;
   box-shadow: var(--vp-shadow-1);
   transition:
@@ -346,7 +371,7 @@ h1.title {
     transform 0.2s ease;
 }
 .VPFeature:hover {
-  border-color: var(--kami-brand);
+  border-color: var(--vp-c-brand-1);
   box-shadow: var(--vp-shadow-2);
   transform: translateY(-2px);
 }
@@ -354,20 +379,20 @@ h1.title {
   font-family: var(--kami-serif);
   font-weight: 500;
   font-size: 1.15rem;
-  color: var(--kami-near-black);
+  color: var(--vp-c-text-1);
 }
 .VPFeature .details {
-  color: var(--kami-olive);
+  color: var(--vp-c-text-2);
   line-height: 1.6;
   font-size: 0.9rem;
 }
 .VPFeature .link-text-value {
-  color: var(--kami-brand);
+  color: var(--vp-c-brand-1);
   font-weight: 500;
 }
 /* feature 图标：缩小、去饱和，避免 emoji 喧宾夺主（Kami #19） */
 .VPFeature .icon {
-  background: var(--kami-tint) !important;
+  background: var(--vp-c-brand-soft) !important;
   border-radius: 8px;
   font-size: 20px !important;
   filter: saturate(0.85);
@@ -378,7 +403,7 @@ h1.title {
    ============================================================ */
 .vp-doc .custom-block {
   border-radius: 8px;
-  border: 1px solid var(--kami-border);
+  border: 1px solid var(--vp-c-border);
 }
 .vp-doc .custom-block.tip {
   border-color: transparent;
@@ -391,12 +416,12 @@ h1.title {
 
 /* 页脚 */
 .VPFooter {
-  border-top: 1px solid var(--kami-border);
-  background: var(--kami-parchment-2);
+  border-top: 1px solid var(--vp-c-divider);
+  background: var(--vp-c-bg-alt);
 }
 .VPFooter .message,
 .VPFooter .copyright {
-  color: var(--kami-stone);
+  color: var(--vp-c-text-3);
   font-size: 0.82rem;
 }
 

--- a/docs-site/guide/getting-started.md
+++ b/docs-site/guide/getting-started.md
@@ -37,8 +37,10 @@ cndiv export --year=2023 --output=divisions-2023.csv
 # 校验并解压
 shasum -a 256 -c SHA256SUMS.txt
 tar -xzf nbs-sqlite-2009-2023.tar.gz
-sqlite3 NBS.2023.sqlite "SELECT count(*) FROM village;"   # → 620573
+sqlite3 NBS.2023.sqlite "SELECT count(*) FROM village;"   # → 620573（原始 NBS 表）
 ```
+
+> `620573` 是**原始 NBS 直采成品**的村级计数。而 `cndiv hydrate` 注水的**分发基线**会丢弃 NBS 的自指占位行（直筒子市、金门县等 `parent === code` 的补位记录），村级为 **620,572**——首页与图表所示即此。两者相差 1 属预期,非数据错误。
 
 逐文件 SHA-256 完整性清单与数据字典见 [历年快照与下载](/data/snapshots)。
 

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -5,6 +5,9 @@ hero:
   name: 中国行政区划数据基础设施
   text: 后统计局时代的可持续更新方案
   tagline: GB2260 国标（省/市/县，1980–2023）＋ NBS 统计用区划代码五级（省/市/县/乡/村，2009–2023）历年快照。2023 基线 ＋ 社区 Patch 增量 ＋ 多源合成，数据与代码彻底解耦。
+  image:
+    src: /logo.svg
+    alt: cndiv —— 行政区划逐级细分标识
   actions:
     - theme: brand
       text: 快速上手

--- a/docs-site/public/favicon.svg
+++ b/docs-site/public/favicon.svg
@@ -1,0 +1,14 @@
+<svg viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="cndiv">
+  <!-- 带浅色底板,保证在深色浏览器标签栏也清晰 -->
+  <rect x="0" y="0" width="120" height="120" rx="24" fill="#f7f8fa"/>
+  <rect x="12"   y="12"   width="45"  height="45"  rx="4" fill="#1c3a5c"/>
+  <rect x="63"   y="12"   width="45"  height="45"  rx="4" fill="#2f5a8a"/>
+  <rect x="12"   y="63"   width="45"  height="45"  rx="4" fill="#5a8cc2"/>
+  <rect x="63"   y="63"   width="21"  height="21"  rx="3" fill="#93b8dd"/>
+  <rect x="87"   y="63"   width="21"  height="21"  rx="3" fill="#93b8dd"/>
+  <rect x="63"   y="87"   width="21"  height="21"  rx="3" fill="#93b8dd"/>
+  <rect x="87"   y="87"   width="9.5" height="9.5" rx="2" fill="#c6402f"/>
+  <rect x="98.5" y="87"   width="9.5" height="9.5" rx="2" fill="#c6402f"/>
+  <rect x="87"   y="98.5" width="9.5" height="9.5" rx="2" fill="#c6402f"/>
+  <rect x="98.5" y="98.5" width="9.5" height="9.5" rx="2" fill="#c6402f"/>
+</svg>

--- a/docs-site/public/logo.svg
+++ b/docs-site/public/logo.svg
@@ -1,0 +1,14 @@
+<svg viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="cndiv logo">
+  <title>cndiv · 中国行政区划数据基础设施</title>
+  <!-- 层级细分:向右下角递归四分,省→市→县→乡以靛墨蓝阶梯,村级四格朱砂 -->
+  <rect x="12"   y="12"   width="45"  height="45"  rx="4" fill="#1c3a5c"/>
+  <rect x="63"   y="12"   width="45"  height="45"  rx="4" fill="#2f5a8a"/>
+  <rect x="12"   y="63"   width="45"  height="45"  rx="4" fill="#5a8cc2"/>
+  <rect x="63"   y="63"   width="21"  height="21"  rx="3" fill="#93b8dd"/>
+  <rect x="87"   y="63"   width="21"  height="21"  rx="3" fill="#93b8dd"/>
+  <rect x="63"   y="87"   width="21"  height="21"  rx="3" fill="#93b8dd"/>
+  <rect x="87"   y="87"   width="9.5" height="9.5" rx="2" fill="#c6402f"/>
+  <rect x="98.5" y="87"   width="9.5" height="9.5" rx="2" fill="#c6402f"/>
+  <rect x="87"   y="98.5" width="9.5" height="9.5" rx="2" fill="#c6402f"/>
+  <rect x="98.5" y="98.5" width="9.5" height="9.5" rx="2" fill="#c6402f"/>
+</svg>

--- a/package.json
+++ b/package.json
@@ -33,5 +33,10 @@
     "typescript-eslint": "^8.62.0",
     "vite": "^8.1.0",
     "vitest": "^4.1.9"
+  },
+  "pnpm": {
+    "overrides": {
+      "js-yaml@3": "^3.15.0"
+    }
   }
 }

--- a/packages/source-2023/package.json
+++ b/packages/source-2023/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cndiv/source-2023",
-  "version": "2023.0.0",
+  "version": "2023.0.1",
   "description": "China administrative division data snapshot for year 2023 (NBS five-level: province/city/county/township/village)",
   "license": "MIT",
   "files": [
@@ -27,5 +27,8 @@
     "type": "git",
     "url": "git+https://github.com/tonyc726/china-administrative-division.git",
     "directory": "packages/source-2023"
+  },
+  "scripts": {
+    "prepublishOnly": "node -e \"const s=require('fs').statSync('data/divisions.csv').size;if(s<1e6){console.error('✋ divisions.csv 缺失或过小('+s+'B)——拒绝发布空数据包(CI 无 CSV 源，须本地发布)');process.exit(1)}\""
   }
 }

--- a/packages/source-history/package.json
+++ b/packages/source-history/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cndiv/source-history",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "China administrative division history (GB/T 2260, 1980–2021), year-versioned by composite (code, year)",
   "license": "MIT",
   "files": [
@@ -28,5 +28,8 @@
     "type": "git",
     "url": "git+https://github.com/tonyc726/china-administrative-division.git",
     "directory": "packages/source-history"
+  },
+  "scripts": {
+    "prepublishOnly": "node -e \"const s=require('fs').statSync('data/divisions.csv').size;if(s<1e6){console.error('✋ divisions.csv 缺失或过小('+s+'B)——拒绝发布空数据包(CI 无 CSV 源，须本地发布)');process.exit(1)}\""
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  js-yaml@3: ^3.15.0
+
 importers:
 
   .:
@@ -1337,8 +1340,8 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+  js-yaml@3.15.0:
+    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
     hasBin: true
 
   js-yaml@4.2.0:
@@ -2031,6 +2034,7 @@ packages:
 
   whatwg-encoding@1.0.5:
     resolution: {integrity: sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
@@ -3360,7 +3364,7 @@ snapshots:
   jiti@2.6.1:
     optional: true
 
-  js-yaml@3.14.2:
+  js-yaml@3.15.0:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
@@ -3694,7 +3698,7 @@ snapshots:
   read-yaml-file@1.1.0:
     dependencies:
       graceful-fs: 4.2.11
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       pify: 4.0.1
       strip-bom: 3.0.0
 


### PR DESCRIPTION
## 概述

首发后的文档与门面收尾,聚焦对外**可读性**与**一致性**。净 diff 仅 8 个文件。

## 改动

### 📖 README 可读性重构（172 → 65 行）
- 只保留三件必要信息:是什么 / 怎么跑出第一个结果 / 深入去哪读
- 各包代码示例、数据模型详解、发版流程等下沉到文档站,消除重复
- 顶部加入居中 logo

### 🎨 cndiv 标识（层级细分）
- 新增 `logo.svg`(透明底) / `favicon.svg`(带浅底板,深色标签栏可见)
- 隐喻「行政区划逐级细分」:四阶靛墨蓝(省/市/县/乡) + 朱砂(村级)
- 接入文档站 nav logo、favicon、首页 hero image 与 README

### 🌓 文档站暗色对比度修复（根因）
- `custom.css` 大量规则直接引用亮色固定 token(`--kami-near-black`/`--kami-brand`/`--kami-ivory` 等)且**无 `.dark` 覆盖** → 暗底下正文近黑字、强调深墨蓝字不可见,Feature 卡/表头/引用块变刺眼亮块
- 统一改为随主题切换的 `--vp-c-*` 语义变量:**亮色视觉零变化**,暗色获得正确对比度

### 🔢 村级计数口径消歧
- `620573`(原始 NBS 表)与 `620572`(合成基线)**都对**,非笔误
- 差 1 根因:`build-source.ts` 丢弃 `parent === code` 的 NBS 自指占位行(直筒子市/金门县等)
- `getting-started.md` 加口径说明;原始表计数**不改**(改了用户实跑对不上)

### 🔧 .env.example 补全
- 按代码 `process.env.*` 实际引用补齐并分组:`DOCS_BASE`/`DOCS_SITE_URL`、`USE_OLLAMA`/`DASHSCOPE_API_KEY`、`NETWORK_SMOKE`

## 说明
- 本地 `pnpm --ignore-workspace build`(docs-site)通过。
- commit 列表含已合并的 `6a5299b`(PR #63 squash 合并所致),其改动已在 master、**diff 不重复**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
