### PR TITLE
chore(ci): 加 pnpm audit 门禁覆盖 dev 依赖审计盲区

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Audit dependencies
+        # 扫 pnpm-lock.yaml 全量依赖(含 dev + auto-install 的 optional peer),覆盖常规审计盲区。
+        # 归档目录(legacy/)的漂浮声明不在 lock,由 Dependabot 扫 git package.json 兜底。
+        # 级别 low:任何漏洞阻断 CI;如需放宽改 --audit-level=moderate。
+        run: pnpm audit --audit-level=low
+
       - name: Build (tsc -b, project references)
         run: pnpm build
 


### PR DESCRIPTION
## 背景

两次 Dependabot 告警暴露同一模式--**dev/间接依赖脱离主审计**：

| alert | 根因 | 盲区类型 |
|-------|------|---------|
| #193 adm-zip (high) | legacy 归档目录的 package.json 漂浮声明 | 归档残留 |
| #191 @tootallnate/once (low) | `vitest -> jsdom@16.7.0(peer) -> http-proxy-agent@4 -> @tootallnate/once@1`，pnpm auto-install 装的 optional peer 老版本 | auto-install peer |

`pnpm audit` 默认只扫 workspace 成员声明的依赖树，auto-install 的 optional peer 虽进 lock 但项目不显式声明、不直接使用，潜伏在深层间接依赖里，只能等外部 CVE 通报才暴露。

## 方案

在 CI 的 `Install dependencies` 后、`Build` 前加：

```yaml
- name: Audit dependencies
  run: pnpm audit --audit-level=low
```

扫 `pnpm-lock.yaml` 全量依赖（含 dev + auto-install 的 optional peer），覆盖该盲区。级别 `low`：任何漏洞阻断 CI（与两次告警都修的处理标准一致）；如需放宽改 `--audit-level=moderate`。

## 覆盖边界

| 盲区类型 | pnpm audit 能否覆盖 |
|---------|---------------------|
| auto-install optional peer（#191 类，进 lock） | ✓ 覆盖 |
| 归档目录残留（#193 类，不在 lock） | ✗ 不覆盖，靠 Dependabot 扫 git package.json 兜底（已生效） |

## 验证

- 本地 `pnpm audit --audit-level=low`：✓ `No known vulnerabilities found`（当前全 fixed）
- yaml 语法：✓ python yaml 校验通过
- 缩进与现有步骤一致（8 空格 `- name`，10 空格 `run:`）

## 关联

- 前序 PR：#65（删 legacy/package.json）、#66（升级 jsdom）
- 两个告警当前均已 `fixed`，此 PR 是防止同类问题复发的结构性门禁