### PR TITLE
fix: SVG logo 缺少 width/height 导致 img 标签 naturalWidth=0

### DIFF
--- a/apps/web/public/favicon.svg
+++ b/apps/web/public/favicon.svg
@@ -2,7 +2,7 @@
      favicon 环境不用 CSS 变量，hex 与 v8 概念页一致。
      36/34 grid，16px 下完整外框仍可识别。
      改动请同步 BrandMark.tsx。 -->
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 34 34">
+<svg width="34" height="34" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 34 34">
   <!-- 外框：暖纸底 -->
   <rect x="0.5" y="0.5" width="33" height="33" rx="8" fill="#faf9f5" stroke="#d5cec0"/>
   <!-- 珊瑚橙印面：与 --color-clay #cc785c 一致 -->

--- a/docs-site/public/favicon.svg
+++ b/docs-site/public/favicon.svg
@@ -1,5 +1,5 @@
 <!-- 与 apps/web/public/favicon.svg 同源 v8 多宝塔法度 -->
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 34 34">
+<svg width="34" height="34" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 34 34">
   <rect x="0.5" y="0.5" width="33" height="33" rx="8" fill="#faf9f5" stroke="#d5cec0"/>
   <rect x="4.5" y="4.5" width="25" height="25" rx="2.5" fill="#cc785c"/>
   <g fill="#faf9f5">

--- a/docs-site/public/logo.svg
+++ b/docs-site/public/logo.svg
@@ -1,6 +1,6 @@
 <!-- 九州印章 v8 · 多宝塔法度 · 与 apps/web/src/components/BrandMark.tsx 同源
      硬编码 hex（VitePress 环境无 CSS 变量），改动请同步 BrandMark.tsx 及 favicon.svg -->
-<svg viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="cndiv · 九州印章">
+<svg width="34" height="34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="cndiv · 九州印章">
   <title>cndiv · 中国行政区划数据基础设施</title>
   <!-- 外框：暖纸底 + hairline 描边 -->
   <rect x="0.5" y="0.5" width="33" height="33" rx="8" fill="#faf9f5" stroke="#d5cec0"/>


### PR DESCRIPTION
docs-site hero 页 logo 渲染为 0x0，原因是 SVG 有 viewBox 但无 width/height 属性。三个文件统一加上 width=34 height=34。