### PR TITLE
fix: SVG XML 注释中的 -- 双连字符导致 logo naturalWidth=0

### DIFF
--- a/apps/web/public/favicon.svg
+++ b/apps/web/public/favicon.svg
@@ -5,7 +5,7 @@
 <svg width="34" height="34" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 34 34">
   <!-- 外框：暖纸底 -->
   <rect x="0.5" y="0.5" width="33" height="33" rx="8" fill="#faf9f5" stroke="#d5cec0"/>
-  <!-- 珊瑚橙印面：与 --color-clay #cc785c 一致 -->
+  <!-- 珊瑚橙印面：与品牌色 cc785c 一致 -->
   <rect x="4.5" y="4.5" width="25" height="25" rx="2.5" fill="#cc785c"/>
   <!-- 州 · 多宝塔法度 -->
   <g fill="#faf9f5">

--- a/docs-site/public/logo.svg
+++ b/docs-site/public/logo.svg
@@ -4,7 +4,7 @@
   <title>cndiv · 中国行政区划数据基础设施</title>
   <!-- 外框：暖纸底 + hairline 描边 -->
   <rect x="0.5" y="0.5" width="33" height="33" rx="8" fill="#faf9f5" stroke="#d5cec0"/>
-  <!-- 珊瑚橙印面：与 --color-clay #cc785c 一致 -->
+  <!-- 珊瑚橙印面：与品牌色 cc785c 一致 -->
   <rect x="4.5" y="4.5" width="25" height="25" rx="2.5" fill="#cc785c"/>
   <!-- 州 · 多宝塔法度 -->
   <g fill="#faf9f5">


### PR DESCRIPTION
根因：SVG 注释 `<!-- 珊瑚橙印面：与 --color-clay #cc785c 一致 -->` 中的 `--color-clay` 包含 XML 非法双连字符 `--`，导致 SVG 作为 img 标签加载时 XML 解析失败，naturalWidth/naturalHeight 为 0。

修复：注释中 `--color-clay` 改为 `品牌色`。