### PR TITLE
fix(docs): hero 间距与地图层级调整

### DIFF
--- a/docs-site/.vitepress/theme/components/ChinaMapHero.vue
+++ b/docs-site/.vitepress/theme/components/ChinaMapHero.vue
@@ -78,8 +78,8 @@ async function draw() {
     return [lng * s + ox, h - (lat * s - minY * s + pad)];
   }
 
-  const fill = 'rgba(204,120,92,0.07)';
-  const stroke = 'rgba(204,120,92,0.30)';
+  const fill = 'rgba(204,120,92,0.04)';
+  const stroke = 'rgba(204,120,92,0.18)';
 
   for (const p of provs) {
     ctx.beginPath();
@@ -130,7 +130,7 @@ function insets(
   const ss = Math.min(ix / rangeX, iy / rangeY);
 
   ctx.save();
-  ctx.strokeStyle = 'rgba(204,120,92,0.22)';
+  ctx.strokeStyle = 'rgba(204,120,92,0.14)';
   ctx.lineWidth = 0.8;
   ctx.strokeRect(rx, ry, ix, iy);
 
@@ -158,9 +158,9 @@ function insets(
       }
     }
     ctx.closePath();
-    ctx.fillStyle = 'rgba(204,120,92,0.08)';
+    ctx.fillStyle = 'rgba(204,120,92,0.05)';
     ctx.fill();
-    ctx.strokeStyle = 'rgba(204,120,92,0.18)';
+    ctx.strokeStyle = 'rgba(204,120,92,0.12)';
     ctx.lineWidth = 0.4;
     ctx.stroke();
   }

--- a/docs-site/.vitepress/theme/custom.css
+++ b/docs-site/.vitepress/theme/custom.css
@@ -372,6 +372,17 @@ h1.title {
   max-height: 240px;
 }
 
+/* hero 底部减距 + 地图作背景层 */
+.VPHero.VPHomeHero {
+  padding-bottom: 48px;
+}
+.VPHero .image {
+  z-index: 0;
+}
+.VPHero .image .image-bg {
+  opacity: 0.28;
+}
+
 /* 主 CTA：珊瑚橙实心（品牌色保留，双模式白字可读）；次 CTA：暖底描边 */
 .VPButton.brand {
   background: var(--claude-coral);


### PR DESCRIPTION
hero 底部 padding 从默认 ~96px 减至 48px；地图 image 容器 z-index: 0 + 透明度降低，退为背景层。