### PR TITLE
fix(docs): geo.json 本地 dev 路径解析为协议相对 URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -694,3 +694,5 @@ raw/
 
 # hallmark 设计工具运行时产物（设计令牌文档 DESIGN.md 入库，工具状态不入库）
 .hallmark/
+# docs-site 本地开发数据（从 apps/web/public/data 拷贝）
+docs-site/public/data/

--- a/docs-site/.vitepress/theme/components/ChinaMapHero.vue
+++ b/docs-site/.vitepress/theme/components/ChinaMapHero.vue
@@ -37,10 +37,12 @@ async function draw() {
   // Fetch geo JSON from main site (docs is under /docs/ subpath)
   let provs: Province[] = [];
   try {
-    // Docs BASE: /china-administrative-division/docs/ → parent: /china-administrative-division/
+    // Deployed GH Pages: BASE=/china-administrative-division/docs/ → parent=/china-administrative-division
+    // Local dev:         BASE=/ → parent='' → url='/data/geo.json' (needs copy in public/)
     const docsBase = (import.meta.env.BASE_URL || '/').replace(/\/$/, '');
-    const parentBase = docsBase.replace(/\/docs$/, '') || '/';
-    const resp = await fetch(`${parentBase}/data/geo.json`);
+    const parentBase = docsBase.replace(/\/docs$/, '');
+    const url = parentBase ? `${parentBase}/data/geo.json` : '/data/geo.json';
+    const resp = await fetch(url);
     if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
     const geo = await resp.json();
     provs = geo.provs || [];


### PR DESCRIPTION
BASE_URL=/ 时 parentBase 为空，拼接出 //data/geo.json 被浏览器解析为 http://data/geo.json。改为空时直接用 /data/geo.json；本地 dev 需拷贝 geo.json 到 docs-site/public/data/。