### PR TITLE
feat(docs): 替换header&主页Feature卡片的图标

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -153,7 +153,7 @@ export function App({ prerendered }: AppProps): JSX.Element {
               className="hidden text-ink-3 transition hover:text-ink sm:block"
             >
               <svg viewBox="0 0 16 16" className="h-5 w-5" fill="currentColor" aria-hidden="true">
-                <path fillRule="evenodd" d="M3 2a1 1 0 00-1 1v10a1 1 0 001 1h10a1 1 0 001-1V6h-3.5a.5.5 0 01-.5-.5V2H3zm1 3.5h8v1H4v-1zm0 3h8v1H4v-1zm0 3h5v1H4v-1z" clipRule="evenodd" />
+                <path d="M1 2.5A1.5 1.5 0 012.5 1H3v13h-.5A1.5 1.5 0 011 12.5v-10zM4 1h9.5A1.5 1.5 0 0115 2.5v10a1.5 1.5 0 01-1.5 1.5H4V1zm1 1.5v10h8.5a.5.5 0 00.5-.5v-10a.5.5 0 00-.5-.5H5zm1 1h6v1H6v-1zm0 2h6v1H6v-1zm0 2h3v1H6v-1z" />
               </svg>
             </a>
             <a

--- a/docs-site/.vitepress/theme/custom.css
+++ b/docs-site/.vitepress/theme/custom.css
@@ -448,6 +448,16 @@ h1.title {
   border-radius: 8px;
   font-size: 20px !important;
   filter: saturate(0.85);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.VPFeature .icon svg {
+  color: var(--claude-coral);
+  display: block;
+}
+.dark .VPFeature .icon svg {
+  color: var(--vp-c-brand-1);
 }
 
 /* ============================================================

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -21,26 +21,32 @@ features:
     details: 国家统计局 stats.gov.cn 自 2024 年停更、2026 转向国家地名信息库。v2 以 2023 五级全量为不可变基线，村级 620,572 条冻结留档。
     link: /data/snapshots
     linkText: 下载历年快照
+    icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"/><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/></svg>
   - title: 社区 Patch 增量
     details: 撤县设区、更名、新设社区等变更以 JSON Patch 提交，validatePatch 结构性门禁 ＋ CI 自动校验，逐年可追溯、可回放。
     link: /guide/contributing-patch
     linkText: 贡献 Patch
+    icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="6" r="3"/><path d="M13 6h3a2 2 0 012 2v7"/><line x1="6" y1="9" x2="6" y2="21"/></svg>
   - title: 用户侧零爬虫
     details: cndiv hydrate 从 NPM 拉取数据包注水到本地 SQLite，标准 SQLite 可直接 SQL 查询，大数据不进 git。
     link: /guide/getting-started
     linkText: CLI 注水
+    icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
   - title: 纯函数码工具
     details: "@cndiv/core 零依赖：校验、解析 12 位区划码（2＋2＋2＋3＋3），判级、取父码、补零。TS 严格类型，浏览器 / Node / 边缘皆可跑。"
     link: /reference/core
     linkText: 码工具 API
+    icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3H7a2 2 0 00-2 2v5a2 2 0 002 2h1"/><path d="M16 21h1a2 2 0 002-2v-5a2 2 0 00-2-2h-1"/><path d="M8 21H7a2 2 0 01-2-2v-5c0-1.1.9-2 2-2h1"/><path d="M16 3h1a2 2 0 012 2v5c0 1.1-.9 2-2 2h-1"/></svg>
   - title: 只读查询 API
     details: "@cndiv/reader 薄封装 better-sqlite3，自动屏蔽复合主键 (code, year) 与直辖市「市辖区」占位层两个坑。"
     link: /reference/reader
     linkText: 查询 API
+    icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
   - title: 增量采集引擎
     details: "@cndiv/crawler 对接国家地名信息库（dmfw）逐层 BFS 采集，canonicalizeParent 归一化占位层消解假 move，差分产出 Patch。"
     link: /reference/crawler
     linkText: 采集引擎
+    icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 2a14.5 14.5 0 010 20 14.5 14.5 0 010-20"/><path d="M2 12h20"/></svg>
 ---
 
 ## 三行上手


### PR DESCRIPTION
## 改动

- **主站头部**：'文档站'链接图标从通用文件图标替换为书本图标
- **文档站首页**：6 张 Feature 卡片新增内联 SVG 图标
- **CSS**：图标珊瑚橙着色 + flex 居中，light/dark 双主题自动适配

### 图标对照

| 卡片 | 图标 |
|---|---|
| 2023 全量基线快照 | database |
| 社区 Patch 增量 | git-pull-request |
| 用户侧零爬虫 | download |
| 纯函数码工具 | braces |
| 只读查询 API | search |
| 增量采集引擎 | globe |