### PR TITLE
fix(deps): override undici to ^7.29.0 to resolve 5 Dependabot alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "pnpm": {
     "overrides": {
-      "brace-expansion": "^5.0.8",
+      "brace-expansion": "^5.0.9",
       "js-yaml@3": "^3.15.0",
       "js-yaml@4": "^4.3.0",
       "postcss": "^8.5.18",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
       "brace-expansion": "^5.0.8",
       "js-yaml@3": "^3.15.0",
       "js-yaml@4": "^4.3.0",
-      "postcss": "^8.5.18"
+      "postcss": "^8.5.18",
+      "undici": "^7.29.0"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   js-yaml@3: ^3.15.0
   js-yaml@4: ^4.3.0
   postcss: ^8.5.18
+  undici: ^7.29.0
 
 importers:
 
@@ -1904,8 +1905,8 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   universalify@0.1.2:
@@ -2814,7 +2815,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 7.28.0
+      undici: 7.29.0
       whatwg-mimetype: 4.0.0
 
   chownr@1.1.4: {}
@@ -3842,7 +3843,7 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   universalify@0.1.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  brace-expansion: ^5.0.8
+  brace-expansion: ^5.0.9
   js-yaml@3: ^3.15.0
   js-yaml@4: ^4.3.0
   postcss: ^8.5.18
@@ -858,8 +858,8 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -2759,7 +2759,7 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -3448,7 +3448,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
## 修复内容\n\n在 workspace root 的 "pnpm.overrides" 中强制将 undici 提升到 ，解决 5 条 Dependabot 安全告警：\n\n- #198 (high, CVSS 7.4)\n- #199 (medium, CVSS 4.8)\n- #200 (medium, CVSS 4.8)\n- #201 (medium, CVSS 5.9)\n- #202 (medium, CVSS 4.2)\n\n## 根因\n\n →  → ，lockfile 原解析到存在漏洞的 。\n\n## 验证\n\n- Scope: all 10 workspace projects
Lockfile is up to date, resolution step is skipped
Already up to date

. prepare$ git config core.hooksPath .githooks || true
. prepare: Done
Done in 510ms 后 lockfile 中 undici 已更新为 \n- 
> @cndiv/monorepo@2.0.0 typecheck /Users/zhujiangfeng/Playground/china-administrative-division
> tsc -b 通过\n- 
> @cndiv/crawler@1.0.1 test /Users/zhujiangfeng/Playground/china-administrative-division/packages/crawler
> vitest run


 RUN  v4.1.9 /Users/zhujiangfeng/Playground/china-administrative-division/packages/crawler


 Test Files  12 passed | 1 skipped (13)
      Tests  90 passed | 2 skipped (92)
   Start at  17:45:22
   Duration  574ms (transform 734ms, setup 0ms, import 1.96s, tests 195ms, environment 1ms): 90 passed, 2 skipped\n- ┌─────────────────────┬────────────────────────────────────────────────────────┐
│ high                │ brace-expansion: DoS via unbounded intermediate        │
│                     │ arrays, bypassing the CVE-2026-14257 mitigation        │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ brace-expansion                                        │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ >=4.0.0 <5.0.9                                         │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=5.0.9                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ . > @eslint/js@10.0.1 > eslint@10.5.0 >                │
│                     │ @eslint/config-array@0.23.5 > minimatch@10.2.5 >       │
│                     │ brace-expansion@5.0.8                                  │
│                     │                                                        │
│                     │ . > @eslint/js@10.0.1 > eslint@10.5.0 >                │
│                     │ minimatch@10.2.5 > brace-expansion@5.0.8               │
│                     │                                                        │
│                     │ . > eslint@10.5.0 > @eslint/config-array@0.23.5 >      │
│                     │ minimatch@10.2.5 > brace-expansion@5.0.8               │
│                     │                                                        │
│                     │ ... Found 30 paths, run `pnpm why brace-expansion` for │
│                     │ more information                                       │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-rgw5-rvv9-x895      │
└─────────────────────┴────────────────────────────────────────────────────────┘
1 vulnerabilities found
Severity: 1 high 不再报告 undici 相关告警